### PR TITLE
Add shortest possible DNS name.

### DIFF
--- a/pkg/deployments/activator/index.go
+++ b/pkg/deployments/activator/index.go
@@ -90,6 +90,7 @@ func (a *activator) updateIndex() {
 		}
 
 		svcDNSNames := []string{
+			fmt.Sprintf("%s", svc.Name),
 			fmt.Sprintf("%s.%s", svc.Name, svc.Namespace),
 			fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
 			fmt.Sprintf("%s.%s.svc.cluster", svc.Name, svc.Namespace),


### PR DESCRIPTION
**Description of Changes**

Adding the shortest possible DNS entry to the activator. This way it will scale the deployment if another deployment within the same namespace does a request on just the service name.

**Benefits**

Now all the possible DNS entries are covered and it will scale correctly when a local deployment will reach out to another deployment by it's service name.

---

Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>