### PR TITLE
fix: app activation timeout was too short

### DIFF
--- a/pkg/deployments/activator/request_handling.go
+++ b/pkg/deployments/activator/request_handling.go
@@ -1,6 +1,7 @@
 package activator
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/golang/glog"
@@ -70,7 +71,9 @@ func (a *activator) handleRequest(
 			)
 			// Initiate activation (or discover that it may already have been started
 			// by another activator process)
-			appActivation, err = a.activate(r.Context(), app)
+			ctx, cancelFunc := context.WithTimeout(context.Background(), a.appActivationTimeout)
+			defer cancelFunc()
+			appActivation, err = a.activate(ctx, app)
 			if err != nil {
 				glog.Errorf(
 					"%s activation for %s in namespace %s failed: %s",


### PR DESCRIPTION
the app activation was linked to the request that initiated the activation. so if the request was cancelled after 1 second, an app activation with a dependency would fail to activate the real app.
we're using an hardcoded timeout of 5 minutes for the moment. if needed we'll make it configurable later