### PR TITLE
chore: fix CI linter job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run linters
-        uses: actions-contrib/golangci-lint@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          golangci_lint_version: v1.24
+          version: v1.37


### PR DESCRIPTION
fixes

    Error: Unable to resolve action `actions-contrib/golangci-lint@v1`, repository not found

uses https://github.com/marketplace/actions/run-golangci-lint instead