### PR TITLE
fix: ensure we won't close a closed channel

### DIFF
--- a/pkg/deployments/activator/app_activation.go
+++ b/pkg/deployments/activator/app_activation.go
@@ -19,6 +19,7 @@ type appActivation struct {
 	readyAppPodIPs map[string]struct{}
 	endpoints      *corev1.Endpoints
 	lock           sync.Mutex
+	done           bool
 	successCh      chan struct{}
 	timeoutCh      chan struct{}
 	dependencies   []*appActivation
@@ -119,7 +120,10 @@ func (a *appActivation) checkActivationComplete() {
 			for _, address := range subset.Addresses {
 				if _, ok := a.readyAppPodIPs[address.IP]; ok {
 					glog.Infof("App pod with ip %s is in service", address.IP)
-					close(a.successCh)
+					if !a.done {
+						close(a.successCh)
+						a.done = true
+					}
 					return
 				}
 			}


### PR DESCRIPTION
```
E0615 15:31:37.754676       1 runtime.go:78] Observed a panic: "close of closed channel" (close of closed channel)
goroutine 230096 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1612080, 0x197e6c0)
	/home/runner/work/osiris/osiris/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/runner/work/osiris/osiris/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x89
panic(0x1612080, 0x197e6c0)
	/opt/hostedtoolcache/go/1.15.12/x64/src/runtime/panic.go:969 +0x1b9
github.com/dailymotion-oss/osiris/pkg/deployments/activator.(*appActivation).checkActivationComplete(0xc001730d00)
	/home/runner/work/osiris/osiris/pkg/deployments/activator/app_activation.go:122 +0x2c5
github.com/dailymotion-oss/osiris/pkg/deployments/activator.(*appActivation).syncPod(0xc001730d00, 0x17b6000, 0xc000e303e8)
	/home/runner/work/osiris/osiris/pkg/deployments/activator/app_activation.go:106 +0x190
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
	/home/runner/work/osiris/osiris/vendor/k8s.io/client-go/tools/cache/controller.go:227
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
```