### PR TITLE
Osiris apiVersion update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # https://help.github.com/en/articles/about-code-owners
-* @antho-pastor
+* @anthony-pastor
 * @cyril-corbon
 * @yosri-daily
 * @JordanGoasdoue

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # https://help.github.com/en/articles/about-code-owners
-* @vbehar
+* @antho-pastor
+* @cyril-corbon
+* @yosri-daily
+* @JordanGoasdoue
+* @raphael-messner
+* @alextriquet
+* @Bencyril

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,4 +43,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.37
-        args: --timeout=5m
+          args: --timeout=5m

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,3 +43,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.37
+        args: --timeout=5m

--- a/charts/osiris/templates/endpoints-hijacker-webhook-config.yaml
+++ b/charts/osiris/templates/endpoints-hijacker-webhook-config.yaml
@@ -18,7 +18,7 @@ data:
   tls.crt: {{ b64enc $cert.Cert }}
   tls.key: {{ b64enc $cert.Key }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "osiris.fullname" . }}-endpoints-hijacker
@@ -46,3 +46,5 @@ webhooks:
     - CREATE
     - UPDATE
   failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/osiris/templates/proxy-injector-webhook-config.yaml
+++ b/charts/osiris/templates/proxy-injector-webhook-config.yaml
@@ -18,7 +18,7 @@ data:
   tls.crt: {{ b64enc $cert.Cert }}
   tls.key: {{ b64enc $cert.Key }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "osiris.fullname" . }}-proxy-injector
@@ -45,3 +45,5 @@ webhooks:
     operations:
     - CREATE
   failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]


### PR DESCRIPTION
Change apiVersion to fix issue on leo-jx-env:

`flux-system	kustomization/flux-system-components 	False	Service/flux-system/helm-controller-metrics dry-run failed, reason: BadRequest, error: admission webhook "endpoints-hijacker.osiris.dm.gg" does not support dry run	            	False    	
`

See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122