### PR TITLE
Let dependabot make as many action PRs as it needs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Currently `package-ecosystem: "gomod"` has no PR limit, but actions has the default limit of 5: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

This should explain why the other actions didn't have open PRs (see #122).