### PR TITLE
Dynamic ports

### DIFF
--- a/charts/osiris/templates/endpoints-hijacker-deployment.yaml
+++ b/charts/osiris/templates/endpoints-hijacker-deployment.yaml
@@ -39,9 +39,11 @@ spec:
           value: /osiris/cert/tls.crt
         - name: TLS_KEY_FILE
           value: /osiris/cert/tls.key
+        - name: SECURE_PORT
+          value: "{{ .Values.endpointsHijacker.webhooks.securePort }}"
         ports:
         - name: https
-          containerPort: 5000
+          containerPort: {{ .Values.endpointsHijacker.webhooks.securePort }}
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/charts/osiris/templates/endpoints-hijacker-webhook-config.yaml
+++ b/charts/osiris/templates/endpoints-hijacker-webhook-config.yaml
@@ -54,6 +54,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.endpointsHijacker.webhooks.failurePolicy }}
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/osiris/values.yaml
+++ b/charts/osiris/values.yaml
@@ -115,6 +115,7 @@ endpointsHijacker:
   affinity: {}
   webhooks:
     failurePolicy: Ignore
+    securePort: 5000
 
 certmanager:
     # -- Enables cert-manager to automatically issue selfSigned certificates

--- a/charts/osiris/values.yaml
+++ b/charts/osiris/values.yaml
@@ -115,7 +115,7 @@ endpointsHijacker:
   affinity: {}
   webhooks:
     failurePolicy: Ignore
-    securePort: 5000
+    securePort: 10250
 
 certmanager:
     # -- Enables cert-manager to automatically issue selfSigned certificates

--- a/charts/osiris/values.yaml
+++ b/charts/osiris/values.yaml
@@ -113,6 +113,8 @@ endpointsHijacker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  webhooks:
+    failurePolicy: Ignore
 
 certmanager:
     # -- Enables cert-manager to automatically issue selfSigned certificates

--- a/pkg/endpoints/hijacker/config.go
+++ b/pkg/endpoints/hijacker/config.go
@@ -9,6 +9,7 @@ const envconfigPrefix = "OSIRIS_ENDPOINTS_HIJACKER"
 type Config struct {
 	TLSCertFile string `envconfig:"TLS_CERT_FILE" required:"true"`
 	TLSKeyFile  string `envconfig:"TLS_KEY_FILE" required:"true"`
+	SecurePort  int32  `envconfig:"SECURE_PORT" default:"5000"`
 }
 
 // NewConfigWithDefaults returns a Config object with default values already

--- a/pkg/endpoints/hijacker/hijacker.go
+++ b/pkg/endpoints/hijacker/hijacker.go
@@ -19,8 +19,6 @@ import (
 	"github.com/dailymotion-oss/osiris/pkg/kubernetes"
 )
 
-const port = 5000
-
 // Hijacker is an interface for a component that handles webhook requests
 // for patching Osiris-enabled services in a manner that will permit the
 // Osiris endpoints controller to manage service endpoints
@@ -51,7 +49,7 @@ func NewHijacker(config Config) Hijacker {
 			runtime.NewScheme(),
 		).UniversalDeserializer(),
 		srv: &http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
+			Addr:    fmt.Sprintf(":%d", config.SecurePort),
 			Handler: mux,
 		},
 	}


### PR DESCRIPTION
GKE limits access to things to 443 and 10250. 

cert-manager's helm chart uses 10250 in order to work on GKE smoothly.

I've also included a changeset to support changing the `failurePolicy` to `Fail` which was helpful in debugging this...

We're running w/ this, and it at least helped us make some progress...